### PR TITLE
change to use `sprintf-js` since `sprintf` is deprecated

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -21,7 +21,7 @@
 const path       = require('path');
 const fs         = require('fs');
 const mkdirp     = require('mkdirp');
-const vsprintf   = require('sprintf').vsprintf;
+const vsprintf   = require('sprintf-js').vsprintf;
 const langParser = require('accept-language-parser');
 const flatten    = require('flat');
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,610 +1,824 @@
 {
   "name": "i18n-x",
-  "version": "0.1.1",
+  "version": "0.1.4",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "accept-language-parser": {
       "version": "1.3.0",
-      "from": "accept-language-parser@1.3.0",
-      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.3.0.tgz",
+      "integrity": "sha1-Ib5OD0aj9pWgzwjt0tlVNpIh8/A="
     },
     "accepts": {
       "version": "1.3.3",
-      "from": "accepts@>=1.3.3 <1.4.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "dev": true
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.11",
+        "negotiator": "0.6.1"
+      }
     },
     "acorn": {
       "version": "3.3.0",
-      "from": "acorn@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
       "dev": true
     },
     "acorn-globals": {
       "version": "3.0.0",
-      "from": "acorn-globals@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-GmTdj6dhKIWUYgZJUm4mJZF6VsY=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.1.0"
+      }
     },
     "align-text": {
       "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "dev": true
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
     },
     "amdefine": {
       "version": "1.0.0",
-      "from": "amdefine@>=0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
       "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
-      "from": "array-flatten@1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "asap": {
       "version": "2.0.4",
-      "from": "asap@>=2.0.3 <2.1.0",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz",
+      "integrity": "sha1-s5G/f2v7xlcGAi/sj0nEsH/s9Yk=",
       "dev": true
     },
     "async": {
       "version": "0.2.10",
-      "from": "async@>=0.2.6 <0.3.0",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
       "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
-      "from": "camelcase@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true
     },
     "center-align": {
       "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "dev": true
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
     },
     "character-parser": {
       "version": "2.2.0",
-      "from": "character-parser@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-      "dev": true
+      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
+      "dev": true,
+      "requires": {
+        "is-regex": "^1.0.3"
+      }
     },
     "clean-css": {
       "version": "3.4.19",
-      "from": "clean-css@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.19.tgz",
-      "dev": true
+      "integrity": "sha1-wyqKE8o7gkYJsUMGpdp22Hk8eHQ=",
+      "dev": true,
+      "requires": {
+        "commander": "2.8.x",
+        "source-map": "0.4.x"
+      }
     },
     "cliui": {
       "version": "2.1.0",
-      "from": "cliui@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      }
     },
     "commander": {
       "version": "2.8.1",
-      "from": "commander@>=2.8.0 <2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-      "dev": true
+      "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
     },
     "constantinople": {
       "version": "3.1.0",
-      "from": "constantinople@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-dWnKqKo/jVk11i4fqW+fcCzYHHk=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.1.0",
+        "is-expression": "^2.0.1"
+      }
     },
     "content-disposition": {
       "version": "0.5.1",
-      "from": "content-disposition@0.5.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+      "integrity": "sha1-h0dsamfI2qh+Muh2Ft+IO6f7Bxs=",
       "dev": true
     },
     "content-type": {
       "version": "1.0.2",
-      "from": "content-type@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
       "dev": true
     },
     "cookie": {
       "version": "0.3.1",
-      "from": "cookie@0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
     "cookie-parser": {
       "version": "1.4.3",
-      "from": "cookie-parser@*",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
-      "dev": true
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
+      "dev": true,
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "from": "cookie-signature@1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
     "debug": {
       "version": "2.2.0",
-      "from": "debug@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "dev": true
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "depd": {
       "version": "1.1.0",
-      "from": "depd@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
       "dev": true
     },
     "destroy": {
       "version": "1.0.4",
-      "from": "destroy@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "doctypes": {
       "version": "1.1.0",
-      "from": "doctypes@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
       "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
-      "from": "ee-first@1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "encodeurl": {
       "version": "1.0.1",
-      "from": "encodeurl@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <1.1.0",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "etag": {
       "version": "1.7.0",
-      "from": "etag@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
       "dev": true
     },
     "express": {
       "version": "4.14.0",
-      "from": "express@*",
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
-      "dev": true
+      "integrity": "sha1-we4/Qs3Ikfs9xlCoki1R7IR9DWY=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.1",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.5.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.2",
+        "qs": "6.2.0",
+        "range-parser": "~1.2.0",
+        "send": "0.14.1",
+        "serve-static": "~1.11.1",
+        "type-is": "~1.6.13",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      }
     },
     "finalhandler": {
       "version": "0.5.0",
-      "from": "finalhandler@0.5.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-      "dev": true
+      "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
+      "dev": true,
+      "requires": {
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "statuses": "~1.3.0",
+        "unpipe": "~1.0.0"
+      }
     },
     "flat": {
       "version": "2.0.1",
-      "from": "flat@*",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
+      "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8=",
+      "requires": {
+        "is-buffer": "~1.1.2"
+      }
     },
     "forwarded": {
       "version": "0.1.0",
-      "from": "forwarded@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
       "dev": true
     },
     "fresh": {
       "version": "0.3.0",
-      "from": "fresh@0.3.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
       "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "http-errors": {
       "version": "1.5.0",
-      "from": "http-errors@>=1.5.0 <1.6.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-      "dev": true
+      "integrity": "sha1-scs9gmD9jiOGytMYkEWUM3LUghE=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1",
+        "setprototypeof": "1.0.1",
+        "statuses": ">= 1.3.0 < 2"
+      }
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
       "dev": true
     },
     "ipaddr.js": {
       "version": "1.1.1",
-      "from": "ipaddr.js@1.1.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
+      "integrity": "sha1-x5HZX1KynBJH1d+AraObinNkcjA=",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.4",
-      "from": "is-buffer@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
     },
     "is-expression": {
       "version": "2.1.0",
-      "from": "is-expression@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-2.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-kb6dR968/vB3l36XIr5tz7RGXvA=",
+      "dev": true,
+      "requires": {
+        "acorn": "~3.3.0",
+        "object-assign": "^4.0.1"
+      }
     },
     "is-promise": {
       "version": "2.1.0",
-      "from": "is-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.3",
-      "from": "is-regex@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
+      "integrity": "sha1-DVUYK9358v3ieCIK7Dp1ZCyQhjc=",
       "dev": true
     },
     "js-stringify": {
       "version": "1.0.2",
-      "from": "js-stringify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
       "dev": true
     },
     "jstransformer": {
       "version": "0.0.3",
-      "from": "jstransformer@0.0.3",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.3.tgz",
-      "dev": true
+      "integrity": "sha1-NHSVvT/hz+jwPi1xV4rLkCSCbPU=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
+      }
     },
     "kind-of": {
       "version": "3.0.4",
-      "from": "kind-of@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-      "dev": true
+      "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.0.2"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "from": "lazy-cache@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
-      "from": "media-typer@0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "from": "merge-descriptors@1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "methods": {
       "version": "1.1.2",
-      "from": "methods@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "mime": {
       "version": "1.3.4",
-      "from": "mime@1.3.4",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
       "dev": true
     },
     "mime-db": {
       "version": "1.23.0",
-      "from": "mime-db@>=1.23.0 <1.24.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.11",
-      "from": "mime-types@>=2.1.11 <2.2.0",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-      "dev": true
+      "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.23.0"
+      }
     },
     "minimist": {
       "version": "0.0.8",
-      "from": "minimist@0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@*",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "ms": {
       "version": "0.7.1",
-      "from": "ms@0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
-      "from": "negotiator@0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
       "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "dev": true
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "parseurl": {
       "version": "1.3.1",
-      "from": "parseurl@>=1.3.1 <1.4.0",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
       "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "from": "path-to-regexp@0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "promise": {
       "version": "7.1.1",
-      "from": "promise@>=7.0.1 <8.0.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
     },
     "proxy-addr": {
       "version": "1.1.2",
-      "from": "proxy-addr@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
-      "dev": true
+      "integrity": "sha1-tMxfImENlTWCTBI675089zxAujc=",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.1.1"
+      }
     },
     "pug": {
       "version": "2.0.0-alpha6",
-      "from": "pug@2.0.0-alpha6",
       "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.0-alpha6.tgz",
-      "dev": true
+      "integrity": "sha1-hViziKghLIx16qPvt7ET34YVNb8=",
+      "dev": true,
+      "requires": {
+        "pug-code-gen": "0.0.7",
+        "pug-filters": "1.2.1",
+        "pug-lexer": "1.0.1",
+        "pug-linker": "0.0.4",
+        "pug-loader": "1.0.2",
+        "pug-parser": "1.0.0",
+        "pug-runtime": "2.0.1",
+        "pug-strip-comments": "0.0.1"
+      }
     },
     "pug-attrs": {
       "version": "2.0.1",
-      "from": "pug-attrs@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-i13XwzBzDAn2Ipnga1j9DrxOv9U=",
+      "dev": true,
+      "requires": {
+        "constantinople": "^3.0.1",
+        "js-stringify": "^1.0.1",
+        "pug-runtime": "^2.0.0"
+      }
     },
     "pug-code-gen": {
       "version": "0.0.7",
-      "from": "pug-code-gen@0.0.7",
       "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-0.0.7.tgz",
-      "dev": true
+      "integrity": "sha1-pXRnWfV+CZ5KF+99MnmKCgAiEHo=",
+      "dev": true,
+      "requires": {
+        "constantinople": "^3.0.1",
+        "doctypes": "^1.0.0",
+        "js-stringify": "^1.0.1",
+        "pug-attrs": "^2.0.1",
+        "pug-error": "^1.3.0",
+        "pug-runtime": "^2.0.0",
+        "void-elements": "^2.0.1",
+        "with": "^5.0.0"
+      }
     },
     "pug-error": {
       "version": "1.3.1",
-      "from": "pug-error@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.1.tgz",
+      "integrity": "sha1-YWJ0JcP4swexw4sQoLbVyOGjWB8=",
       "dev": true
     },
     "pug-filters": {
       "version": "1.2.1",
-      "from": "pug-filters@1.2.1",
       "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-1.2.1.tgz",
-      "dev": true
+      "integrity": "sha1-8Ltdd7Wq6fWCOQdaf4bmX5kCZjQ=",
+      "dev": true,
+      "requires": {
+        "clean-css": "^3.3.0",
+        "constantinople": "^3.0.1",
+        "jstransformer": "0.0.3",
+        "pug-error": "^1.3.0",
+        "pug-walk": "^0.0.3",
+        "resolve": "^1.1.6",
+        "uglify-js": "^2.6.1"
+      }
     },
     "pug-lexer": {
       "version": "1.0.1",
-      "from": "pug-lexer@1.0.1",
       "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-1.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-Narh8JC0ejJSJGW0S4oB5HcX/Qs=",
+      "dev": true,
+      "requires": {
+        "character-parser": "^2.1.1",
+        "is-expression": "^2.0.0",
+        "pug-error": "^1.3.0"
+      }
     },
     "pug-linker": {
       "version": "0.0.4",
-      "from": "pug-linker@0.0.4",
       "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-0.0.4.tgz",
-      "dev": true
+      "integrity": "sha1-65p4Wyqa5KbkLq+f1jfMrmt7MEY=",
+      "dev": true,
+      "requires": {
+        "pug-error": "^1.3.0",
+        "pug-walk": "^0.0.3"
+      }
     },
     "pug-loader": {
       "version": "1.0.2",
-      "from": "pug-loader@1.0.2",
       "resolved": "https://registry.npmjs.org/pug-loader/-/pug-loader-1.0.2.tgz",
-      "dev": true
+      "integrity": "sha1-WovuG4G9Z4HjwLWgaMcixshY+UY=",
+      "dev": true,
+      "requires": {
+        "pug-walk": "0.0.3"
+      }
     },
     "pug-parser": {
       "version": "1.0.0",
-      "from": "pug-parser@1.0.0",
       "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-1.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-Cc9JvzUH8CQ/6VDP6q5cXt9m9CU=",
+      "dev": true,
+      "requires": {
+        "pug-error": "^1.3.0",
+        "token-stream": "0.0.1"
+      }
     },
     "pug-runtime": {
       "version": "2.0.1",
-      "from": "pug-runtime@2.0.1",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.1.tgz",
+      "integrity": "sha1-fO+4t8R3KkvsooOAUar3023oxTY=",
       "dev": true
     },
     "pug-strip-comments": {
       "version": "0.0.1",
-      "from": "pug-strip-comments@0.0.1",
       "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-0.0.1.tgz",
+      "integrity": "sha1-rDRrt3PYJJK/ki2uLUaBogzwY48=",
       "dev": true,
+      "requires": {
+        "pug-error": "^0.0.0"
+      },
       "dependencies": {
         "pug-error": {
           "version": "0.0.0",
-          "from": "pug-error@>=0.0.0 <0.0.1",
           "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-0.0.0.tgz",
+          "integrity": "sha1-3SZKOcINZUh9+F/1ZjCXhioW23g=",
           "dev": true
         }
       }
     },
     "pug-walk": {
       "version": "0.0.3",
-      "from": "pug-walk@>=0.0.3 <0.0.4",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-0.0.3.tgz",
+      "integrity": "sha1-wovnvMVA8kuD0nRHJBCCfITjGsY=",
       "dev": true
     },
     "qs": {
       "version": "6.2.0",
-      "from": "qs@6.2.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+      "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs=",
       "dev": true
     },
     "range-parser": {
       "version": "1.2.0",
-      "from": "range-parser@>=1.2.0 <1.3.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.5.4",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
       "dev": true
     },
     "resolve": {
       "version": "1.1.7",
-      "from": "resolve@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "dev": true
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
     },
     "send": {
       "version": "0.14.1",
-      "from": "send@0.14.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
-      "dev": true
+      "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
+      "dev": true,
+      "requires": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.5.0",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.0"
+      }
     },
     "serve-static": {
       "version": "1.11.1",
-      "from": "serve-static@>=1.11.1 <1.12.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
-      "dev": true
+      "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.14.1"
+      }
     },
     "setprototypeof": {
       "version": "1.0.1",
-      "from": "setprototypeof@1.0.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+      "integrity": "sha1-UgCbJ4iMTcSPWRlJwKgnWDTByn4=",
       "dev": true
     },
     "source-map": {
       "version": "0.4.4",
-      "from": "source-map@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "dev": true
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
     },
-    "sprintf": {
-      "version": "0.1.5",
-      "from": "sprintf@*",
-      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz"
+    "sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "statuses": {
       "version": "1.3.0",
-      "from": "statuses@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+      "integrity": "sha1-jlV1jLIOdoLB9Pzo3KswvwHR4Ho=",
       "dev": true
     },
     "token-stream": {
       "version": "0.0.1",
-      "from": "token-stream@0.0.1",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
+      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo=",
       "dev": true
     },
     "type-is": {
       "version": "1.6.13",
-      "from": "type-is@>=1.6.13 <1.7.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-      "dev": true
+      "integrity": "sha1-boO6e8MM0zp7sLf7AHN6IIW/nQg=",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.11"
+      }
     },
     "uglify-js": {
       "version": "2.7.3",
-      "from": "uglify-js@>=2.6.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
+      "integrity": "sha1-ObOnMpuJ9exQfjRMbiJWhpjvSGg=",
       "dev": true,
+      "requires": {
+        "async": "~0.2.6",
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
-      "from": "unpipe@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
       "dev": true
     },
     "vary": {
       "version": "1.1.0",
-      "from": "vary@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+      "integrity": "sha1-4eWv+70WrnaN0mdDlLmtMCJlMUA=",
       "dev": true
     },
     "void-elements": {
       "version": "2.0.1",
-      "from": "void-elements@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
     "window-size": {
       "version": "0.1.0",
-      "from": "window-size@0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
     },
     "with": {
       "version": "5.1.1",
-      "from": "with@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.1.0",
+        "acorn-globals": "^3.0.0"
+      }
     },
     "wordwrap": {
       "version": "0.0.2",
-      "from": "wordwrap@0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
       "dev": true
     },
     "yargs": {
       "version": "3.10.0",
-      "from": "yargs@>=3.10.0 <3.11.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "dev": true
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,39 +1,34 @@
 {
-      "name"       : "i18n-x"
-    , "version"    : "0.1.4"
-    , "description": "i18n middleware for Express focused on simplicity and modularity (ability to change localization dir dinamically)"
-    , "author"     : "Alexander Zubakov <developer@xinit.ru>"
-    , "license"    : "MIT"
-
-    , "keywords": [
-          "i18n"
-        , "internationalization"
-        , "localization"
-        , "express"
-        , "express.js"
-        , "expressjs"
-    ]
-
-    , "main": "./lib/i18n.js"
-    , "repository": {
-          "type": "git"
-        , "url" : "https://github.com/kolonist/node-i18n-x"
-    }
-
-    , "scripts": {
-          "test": "NODE_ENV=development node test/index.js"
-    }
-
-    , "dependencies": {
-          "accept-language-parser": "*"
-        , "sprintf"               : "*"
-        , "mkdirp"                : "*"
-        , "flat"                  : "*"
-    }
-
-    , "devDependencies": {
-          "express"      : "*"
-        , "cookie-parser": "*"
-        , "pug"          : "2.0.0-alpha6"
-    }
+      "name": "i18n-x",
+      "version": "0.1.4",
+      "description": "i18n middleware for Express focused on simplicity and modularity (ability to change localization dir dinamically)",
+      "author": "Alexander Zubakov <developer@xinit.ru>",
+      "license": "MIT",
+      "keywords": [
+            "i18n",
+            "internationalization",
+            "localization",
+            "express",
+            "express.js",
+            "expressjs"
+      ],
+      "main": "./lib/i18n.js",
+      "repository": {
+            "type": "git",
+            "url": "https://github.com/kolonist/node-i18n-x"
+      },
+      "scripts": {
+            "test": "NODE_ENV=development node test/index.js"
+      },
+      "dependencies": {
+            "accept-language-parser": "*",
+            "sprintf-js": "*",
+            "mkdirp": "*",
+            "flat": "*"
+      },
+      "devDependencies": {
+            "express": "*",
+            "cookie-parser": "*",
+            "pug": "2.0.4"
+      }
 }


### PR DESCRIPTION
need to change to use `sprintf-js`  since `sprintf` is deprecated.
otherwise it will throw error messages during `npm install`